### PR TITLE
fix: no argument parser for 'world_size'

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,6 +18,7 @@ def reduce_loss(tensor, rank, world_size):
 
 parser = argparse.ArgumentParser()
 parser.add_argument('--local_rank', type=int, help="local gpu id")
+parser.add_argument('--world_size', type=int, help="num of processes")
 args = parser.parse_args()
 
 batch_size = 128


### PR DESCRIPTION
hello, in your original codes, there is no argument for receiving world_size. However, in the function of _reduce_loss_, we need world_size as a parameter , and this need to be received by argument parser.